### PR TITLE
drivers: bluetooth: hci: spi: Handle when the buffer is empty

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -10,30 +10,9 @@ if BOARD_DISCO_L475_IOT1
 config BOARD
 	default "disco_l475_iot1"
 
-if BT
-
-choice CLOCK_STM32_SYSCLK_SRC
-	default CLOCK_STM32_SYSCLK_SRC_MSI
-endchoice
-
-if CLOCK_STM32_SYSCLK_SRC_MSI
-
-config CLOCK_STM32_MSI_RANGE
-	default 8
-
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 16000000
-
-endif # CLOCK_STM32_SYSCLK_SRC_MSI
-
-endif #BT
-
-if !BT
 choice CLOCK_STM32_SYSCLK_SRC
 	default CLOCK_STM32_SYSCLK_SRC_PLL
 endchoice
-
-endif #BT
 
 if CLOCK_STM32_SYSCLK_SRC_PLL
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -326,8 +326,8 @@ static void bt_spi_rx_thread(void)
 				    header_slave[STATUS_HEADER_TOREAD] == 0xFF) &&
 				   !ret)) && exit_irq_high_loop());
 
-			if (!ret) {
-				size = header_slave[STATUS_HEADER_TOREAD];
+			size = header_slave[STATUS_HEADER_TOREAD];
+			if (!ret || size != 0) {
 
 				do {
 					ret = bt_spi_transceive(&txmsg, size,
@@ -339,8 +339,10 @@ static void bt_spi_rx_thread(void)
 			gpio_pin_enable_callback(irq_dev, GPIO_IRQ_PIN);
 			k_sem_give(&sem_busy);
 
-			if (ret) {
-				BT_ERR("Error %d", ret);
+			if (ret || size == 0) {
+				if (ret) {
+					BT_ERR("Error %d", ret);
+				}
 				continue;
 			}
 


### PR DESCRIPTION
Check if the buffer size is not empty before SPI transceive and buffer's data processing.
This fixes issues with Beacon, Central and Peripheral (other samples have not been tested) when using BlueNRG-MS chip, and remove the necessity to slow down the MCU to 16MHz when using BlueNRG-MS chip.
Tested platform : disco_l475_iot1, disco_l475_iot1 w/ x-nucleo-idb05a1, stm32mp157c_dk2 w/ x-nucleo-idb05a1

Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>