### PR TITLE
drivers: introduce ipm driver for stm32

### DIFF
--- a/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
+++ b/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
@@ -25,3 +25,10 @@ config UART_7
 endif # SERIAL
 
 endif # BOARD_STM32MP157_Dk2
+
+if IPM
+
+config IPM_STM32_IPCC
+	default y
+
+endif # IPM

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -40,3 +40,7 @@ arduino_serial: &uart7 {};
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&mailbox {
+	status = "okay";
+};

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2_defconfig
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2_defconfig
@@ -19,6 +19,9 @@ CONFIG_PINMUX=y
 # clock configuration
 CONFIG_CLOCK_CONTROL=y
 
+#mailbox
+CONFIG_IPM=y
+
 # console (remote proc console by default)
 CONFIG_CONSOLE=y
 CONFIG_RAM_CONSOLE=y

--- a/drivers/ipm/CMakeLists.txt
+++ b/drivers/ipm/CMakeLists.txt
@@ -6,5 +6,6 @@ zephyr_library_sources_ifdef(CONFIG_IPM_MCUX   ipm_mcux.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_IMX ipm_imx.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_QUARK_SE ipm_quark_se.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_MHU ipm_mhu.c)
+zephyr_library_sources_ifdef(CONFIG_IPM_STM32_IPCC ipm_stm32_ipcc.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   ipm_handlers.c)

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -82,3 +82,19 @@ config IPM_MHU
 	depends on IPM
 	help
 	  Driver for SSE 200 MHU (Message Handling Unit)
+
+config IPM_STM32_IPCC
+	bool "STM32 IPCC controller"
+	default n
+	depends on IPM
+	select USE_STM32_LL_IPCC
+	help
+	  Driver for stm32 IPCC mailboxes
+
+config IPM_STM32_IPCC_PROCID
+	int "STM32 IPCC Processor ID"
+	default 2
+	range 1 2
+	depends on IPM_STM32_IPCC
+	help
+	  use to define the Processor ID for IPCC access

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2019 ST Microelectronics Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <clock_control.h>
+#include <device.h>
+#include <errno.h>
+#include <ipm.h>
+#include <soc.h>
+
+#include <clock_control/stm32_clock_control.h>
+
+#define LOG_LEVEL CONFIG_IPM_LOG_LEVEL
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(ipm_stm32_ipcc);
+
+/* convenience defines */
+#define DEV_CFG(dev)							\
+	((const struct stm32_ipcc_mailbox_config * const)(dev)->config->config_info)
+#define DEV_DATA(dev)							\
+	((struct stm32_ipcc_mbx_data * const)(dev)->driver_data)
+#define MBX_STRUCT(dev)					\
+	((IPCC_TypeDef *)(DEV_CFG(dev))->uconf.base)
+
+#define IPCC_ALL_MR_TXF_CH_MASK 0xFFFF0000
+#define IPCC_ALL_MR_RXO_CH_MASK 0x0000FFFF
+#define IPCC_ALL_SR_CH_MASK	0x0000FFFF
+
+#if (CONFIG_IPM_STM32_IPCC_PROCID == 1)
+
+#define IPCC_EnableIT_TXF(hipcc)  LL_C1_IPCC_EnableIT_TXF(hipcc)
+#define IPCC_DisableIT_TXF(hipcc)  LL_C1_IPCC_DisableIT_TXF(hipcc)
+
+#define IPCC_EnableIT_RXO(hipcc)  LL_C1_IPCC_EnableIT_RXO(hipcc)
+#define IPCC_DisableIT_RXO(hipcc)  LL_C1_IPCC_DisableIT_RXO(hipcc)
+
+#define IPCC_EnableReceiveChannel(hipcc, ch)	\
+			LL_C1_IPCC_EnableReceiveChannel(hipcc, 1 << ch)
+#define IPCC_EnableTransmitChannel(hipcc, ch)	\
+			LL_C1_IPCC_EnableTransmitChannel(hipcc, 1 << ch)
+#define IPCC_DisableReceiveChannel(hipcc, ch)	\
+			LL_C2_IPCC_DisableReceiveChannel(hipcc, 1 << ch)
+#define IPCC_DisableTransmitChannel(hipcc, ch)	\
+			LL_C1_IPCC_DisableTransmitChannel(hipcc, 1 << ch)
+
+#define IPCC_ClearFlag_CHx(hipcc, ch)	LL_C1_IPCC_ClearFlag_CHx(hipcc, 1 << ch)
+#define IPCC_SetFlag_CHx(hipcc, ch)	LL_C1_IPCC_SetFlag_CHx(hipcc, 1 << ch)
+
+#define IPCC_IsActiveFlag_CHx(hipcc, ch)	\
+			LL_C1_IPCC_IsActiveFlag_CHx(hipcc, 1 << ch)
+
+#define IPCC_ReadReg(hipcc, reg) READ_REG(hipcc->C1##reg)
+
+#define IPCC_ReadReg_SR(hipcc) READ_REG(hipcc->C1TOC2SR)
+#define IPCC_ReadOtherInstReg_SR(hipcc) READ_REG(hipcc->C2TOC1SR)
+
+#else
+
+#define IPCC_EnableIT_TXF(hipcc)  LL_C2_IPCC_EnableIT_TXF(hipcc)
+#define IPCC_DisableIT_TXF(hipcc)  LL_C2_IPCC_DisableIT_TXF(hipcc)
+
+#define IPCC_EnableIT_RXO(hipcc)  LL_C2_IPCC_EnableIT_RXO(hipcc)
+#define IPCC_DisableIT_RXO(hipcc)  LL_C2_IPCC_DisableIT_RXO(hipcc)
+
+#define IPCC_EnableReceiveChannel(hipcc, ch)	\
+			LL_C2_IPCC_EnableReceiveChannel(hipcc, 1 << ch)
+#define IPCC_EnableTransmitChannel(hipcc, ch)	\
+			LL_C2_IPCC_EnableTransmitChannel(hipcc, 1 << ch)
+#define IPCC_DisableReceiveChannel(hipcc, ch)	\
+			LL_C2_IPCC_DisableReceiveChannel(hipcc, 1 << ch)
+#define IPCC_DisableTransmitChannel(hipcc, ch)	\
+			LL_C2_IPCC_DisableTransmitChannel(hipcc, 1 << ch)
+
+#define IPCC_ClearFlag_CHx(hipcc, ch)	LL_C2_IPCC_ClearFlag_CHx(hipcc, 1 << ch)
+#define IPCC_SetFlag_CHx(hipcc, ch)	LL_C2_IPCC_SetFlag_CHx(hipcc, 1 << ch)
+
+#define IPCC_IsActiveFlag_CHx(hipcc, ch)	\
+			LL_C2_IPCC_IsActiveFlag_CHx(hipcc, 1 << ch)
+
+#define IPCC_ReadReg(hipcc, reg) READ_REG(hipcc->C2##reg)
+
+#define IPCC_ReadReg_SR(hipcc) READ_REG(hipcc->C2TOC1SR)
+#define IPCC_ReadOtherInstReg_SR(hipcc) READ_REG(hipcc->C1TOC2SR)
+
+#endif
+
+struct stm32_ipcc_mailbox_config {
+	void (*irq_config_func)(struct device *dev);
+	struct stm32_pclken pclken;
+};
+
+struct stm32_ipcc_mbx_data {
+	IPCC_TypeDef *hipcc;
+	u32_t num_ch;
+	ipm_callback_t callback;
+	void *callback_ctx;
+	struct device *clock;
+};
+
+static struct stm32_ipcc_mbx_data stm32_IPCC_data;
+
+static void stm32_ipcc_mailbox_rx_isr(void *arg)
+{
+	struct device *dev = arg;
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
+	unsigned int value = 0;
+	u32_t mask, i;
+
+	mask = (~IPCC_ReadReg(data->hipcc, MR)) & IPCC_ALL_MR_RXO_CH_MASK;
+	mask &= IPCC_ReadOtherInstReg_SR(data->hipcc) & IPCC_ALL_SR_CH_MASK;
+
+	for (i = 0; i < data->num_ch; i++) {
+		if (!((1 << i) & mask)) {
+			continue;
+		}
+		LOG_DBG("%s channel = %x\r\n", __func__, i);
+		/* mask the channel Free interrupt  */
+		IPCC_DisableReceiveChannel(data->hipcc, i);
+
+		if (data->callback) {
+			/* Only one MAILBOX, id is unused and set to 0 */
+			data->callback(data->callback_ctx, i, &value);
+		}
+		/* clear status to acknoledge message reception */
+		IPCC_ClearFlag_CHx(data->hipcc, i);
+		IPCC_EnableReceiveChannel(data->hipcc, i);
+	}
+}
+
+static void stm32_ipcc_mailbox_tx_isr(void *arg)
+{
+	struct device *dev = arg;
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
+	u32_t mask, i;
+
+	mask = (~IPCC_ReadReg(data->hipcc, MR)) & IPCC_ALL_MR_TXF_CH_MASK;
+	mask = mask >> IPCC_C1MR_CH1FM_Pos;
+
+	mask &= IPCC_ReadReg_SR(data->hipcc) & IPCC_ALL_SR_CH_MASK;
+
+	for (i = 0; i <  data->num_ch; i++) {
+		if (!((1 << i) & mask)) {
+			continue;
+		}
+		LOG_DBG("%s channel = %x\r\n", __func__, i);
+		/* mask the channel Free interrupt */
+		IPCC_DisableTransmitChannel(data->hipcc, i);
+	}
+}
+
+static int stm32_ipcc_mailbox_ipm_send(struct device *d, int wait, u32_t id,
+				       const void *buff, int size)
+{
+	struct stm32_ipcc_mbx_data *data = d->driver_data;
+
+	ARG_UNUSED(wait);
+	ARG_UNUSED(buff);
+	ARG_UNUSED(size);
+
+	if (id >= data->num_ch) {
+		LOG_ERR("invalid id (%d)\r\n", id);
+		return  -EINVAL;
+	}
+
+	LOG_DBG("Send msg on channel %d\r\n", id);
+
+	/* Check that the channel is free (otherwise return error) */
+	if (IPCC_IsActiveFlag_CHx(data->hipcc, id)) {
+		LOG_DBG("Waiting for channel to be freed\r\n");
+		while (IPCC_IsActiveFlag_CHx(data->hipcc, id)) {
+			;
+		}
+	}
+	IPCC_EnableTransmitChannel(data->hipcc, id);
+	/* Inform A7 (either new message, or buf free) */
+	IPCC_SetFlag_CHx(data->hipcc, id);
+
+	return 0;
+}
+
+static int stm32_ipcc_mailbox_ipm_max_data_size_get(struct device *d)
+{
+	ARG_UNUSED(d);
+
+	/* Only a single 32-bit register available */
+	return 1;
+}
+
+static u32_t stm32_ipcc_mailbox_ipm_max_id_val_get(struct device *d)
+{
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(d);
+
+	return data->num_ch - 1;
+}
+
+static void stm32_ipcc_mailbox_ipm_register_callback(struct device *d,
+						     ipm_callback_t cb,
+						     void *context)
+{
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(d);
+
+	data->callback = cb;
+	data->callback_ctx = context;
+}
+
+static int stm32_ipcc_mailbox_ipm_set_enabled(struct device *dev, int enable)
+{
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
+	u32_t i;
+
+	/* For now: nothing to be done */
+	LOG_DBG("%s %s mailbox\r\n", __func__, enable ? "enable" : "disable");
+	if (enable) {
+		/* Disable RX and TX interrupts */
+		IPCC_EnableIT_TXF(data->hipcc);
+		IPCC_EnableIT_RXO(data->hipcc);
+		for (i = 0; i < data->num_ch; i++) {
+			IPCC_EnableReceiveChannel(data->hipcc, i);
+		}
+	} else {
+		/* Disable RX and TX interrupts */
+		IPCC_DisableIT_TXF(data->hipcc);
+		IPCC_DisableIT_RXO(data->hipcc);
+		for (i = 0; i < data->num_ch; i++) {
+			IPCC_EnableReceiveChannel(data->hipcc, i);
+		}
+	}
+
+	return 0;
+}
+
+static inline void _stm32_ipcc_get_clock(struct device *dev)
+{
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
+	struct device *clk =
+		device_get_binding(STM32_CLOCK_CONTROL_NAME);
+
+	__ASSERT_NO_MSG(clk);
+
+	data->clock = clk;
+}
+
+static int stm32_ipcc_mailbox_init(struct device *dev)
+{
+
+	struct stm32_ipcc_mbx_data *data = DEV_DATA(dev);
+	const struct stm32_ipcc_mailbox_config *config = DEV_CFG(dev);
+	u32_t i;
+
+	_stm32_ipcc_get_clock(dev);
+	/* enable clock */
+	if (clock_control_on(data->clock,
+			     (clock_control_subsys_t *)&config->pclken) != 0) {
+		return -EIO;
+	}
+
+	data->hipcc = IPCC;
+
+	/* Disable RX and TX interrupts */
+	IPCC_DisableIT_TXF(data->hipcc);
+	IPCC_DisableIT_RXO(data->hipcc);
+
+	data->num_ch = LL_IPCC_GetChannelConfig(data->hipcc);
+
+	for (i = 0; i < data->num_ch; i++) {
+		/* Clear RX status */
+		IPCC_ClearFlag_CHx(data->hipcc, i);
+		/* mask RX and TX interrupts */
+		IPCC_DisableReceiveChannel(data->hipcc, i);
+		IPCC_DisableTransmitChannel(data->hipcc, i);
+	}
+
+	config->irq_config_func(dev);
+
+	return 0;
+}
+
+static const struct ipm_driver_api stm32_ipcc_mailbox_driver_api = {
+	.send = stm32_ipcc_mailbox_ipm_send,
+	.register_callback = stm32_ipcc_mailbox_ipm_register_callback,
+	.max_data_size_get = stm32_ipcc_mailbox_ipm_max_data_size_get,
+	.max_id_val_get = stm32_ipcc_mailbox_ipm_max_id_val_get,
+	.set_enabled = stm32_ipcc_mailbox_ipm_set_enabled,
+};
+
+static void stm32_ipcc_mailbox_config_func(struct device *dev);
+
+/* Config MAILBOX 0 */
+static const struct stm32_ipcc_mailbox_config stm32_ipcc_mailbox_0_config = {
+	.irq_config_func = stm32_ipcc_mailbox_config_func,
+	.pclken = { .bus = DT_INST_0_ST_STM32_IPCC_MAILBOX_CLOCK_BUS,
+		    .enr = DT_INST_0_ST_STM32_IPCC_MAILBOX_CLOCK_BITS
+	},
+
+};
+
+DEVICE_AND_API_INIT(mailbox_0, DT_INST_0_ST_STM32_IPCC_MAILBOX_LABEL,
+		    &stm32_ipcc_mailbox_init,
+		    &stm32_IPCC_data, &stm32_ipcc_mailbox_0_config,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    &stm32_ipcc_mailbox_driver_api);
+
+static void stm32_ipcc_mailbox_config_func(struct device *dev)
+{
+	IRQ_CONNECT(DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_RXO,
+		    DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_RXO_PRIORITY,
+		    stm32_ipcc_mailbox_rx_isr, DEVICE_GET(mailbox_0), 0);
+
+	IRQ_CONNECT(DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_TXF,
+		    DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_TXF_PRIORITY,
+		    stm32_ipcc_mailbox_tx_isr, DEVICE_GET(mailbox_0), 0);
+
+	irq_enable(DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_RXO);
+	irq_enable(DT_INST_0_ST_STM32_IPCC_MAILBOX_IRQ_TXF);
+}

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -210,6 +210,17 @@
 			status = "disabled";
 			label = "UART_8";
 		};
+
+		mailbox: mailbox@4c001000 {
+			compatible = "st,stm32-ipcc-mailbox";
+			reg = <0x4c001000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00001000>;
+			interrupts = <103 0>, <104 0>;
+			interrupt-names = "rxo", "txf";
+			status = "disabled";
+			label = "MAILBOX_0";
+		};
+
 	};
 };
 

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -1,0 +1,17 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+title: STM32 MAILBOX
+version: 0.1
+
+description: >
+  This binding gives a base representation of the STM32 IPCC
+
+inherits:
+    !include base.yaml
+
+properties:
+  clocks:
+    type: array
+    category: required
+    description: Clock gate control information
+    generation: define

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -10,6 +10,9 @@ inherits:
     !include base.yaml
 
 properties:
+  compatible:
+      constraint: "st,stm32-ipcc-mailbox"
+
   clocks:
     type: array
     category: required

--- a/ext/hal/st/stm32cube/stm32mp1xx/README
+++ b/ext/hal/st/stm32cube/stm32mp1xx/README
@@ -54,3 +54,10 @@ Patch List:
       ext/hal/st/stm32cube/stm32mp1xx/README
       ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_rcc.h
     ST Bug tracker ID: BZ65410
+
+    * add new API to get stm32 ipcc num of channel
+
+    allow to read the The IPCC peripheral HWCFGR register to get IPCC number of channels capability.
+    Impacted files:
+       ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_rcc.h
+    ST Bug tracker ID: 68247

--- a/ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_ipcc.h
+++ b/ext/hal/st/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_ipcc.h
@@ -696,6 +696,17 @@ __STATIC_INLINE uint32_t LL_C2_IPCC_IsActiveFlag_CHx(IPCC_TypeDef  const *const 
 }
 
 /**
+  * @brief  get channels configuration.
+  * @rmtoll HWCFGR        CHANNELS         LL_IPCC_GetChannelConfig
+  * @param  IPCCx IPCC Instance.
+  * @retval None
+  */
+__STATIC_INLINE uint32_t LL_IPCC_GetChannelConfig(IPCC_TypeDef *IPCCx)
+{
+  return READ_BIT(IPCCx->HWCFGR, IPCC_HWCFGR_CHANNELS) >> IPCC_HWCFGR_CHANNELS_Pos;
+}
+
+/**
   * @}
   */
 

--- a/soc/arm/st_stm32/stm32mp1/soc.h
+++ b/soc/arm/st_stm32/stm32mp1/soc.h
@@ -46,6 +46,10 @@
 #include <stm32mp1xx_ll_usart.h>
 #endif
 
+#ifdef CONFIG_IPM_STM32_IPCC
+#include <stm32mp1xx_ll_ipcc.h>
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */


### PR DESCRIPTION
IPM driver relies on STM32 IPCC internal peripheral.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>