### PR TITLE
boards: arm: stm32mp157c_dk2: Add Arduino R3 connector definition

### DIFF
--- a/boards/arm/stm32mp157c_dk2/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32mp157c_dk2/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpiof 14 0>,	/* A0 */
+			   <1 0 &gpiof 13 0>,	/* A1 */
+			   /* ANA0 is not a GPIO   A2 */
+			   /* ANA1 is not a GPIO   A3 */
+			   <4 0 &gpioc 3 0>,	/* A4 */
+			   <5 0 &gpiof 12 0>,	/* A5 */
+			   <6 0 &gpioe 7 0>,	/* D0 */
+			   <7 0 &gpioe 8 0>,	/* D1 */
+			   <8 0 &gpioe 1 0>,	/* D2 */
+			   <9 0 &gpiod 14 0>,	/* D3 */
+			   <10 0 &gpioe 10 0>,	/* D4 */
+			   <11 0 &gpiod 15 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiod 1 0>,	/* D7 */
+			   <14 0 &gpiog 3 0>,	/* D8 */
+			   <15 0 &gpioh 6 0>,	/* D9 */
+			   <16 0 &gpioe 11 0>,	/* D10 */
+			   <17 0 &gpioe 14 0>,	/* D11 */
+			   <18 0 &gpioe 13 0>,	/* D12 */
+			   <19 0 &gpioe 12 0>,	/* D13 */
+			   <20 0 &gpioa 12 0>,	/* D14 */
+			   <21 0 &gpioa 11 0>;	/* D15 */
+	};
+};
+
+/* arduino_i2c: I2C is not yet supported on STM32MP1 */
+arduino_serial: &uart7 {};
+/* arduino_spi: SPI is not yet supported on STM32MP1 */

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/mp1/stm32mp157.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32MP157-DK2 board";


### PR DESCRIPTION
Add Arduino R3 connector equivalence to the stm32mp157c_dk2.

Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>