### PR TITLE
boards: shields: x_nucleo_iks01a2: doc: update dead URL link

### DIFF
--- a/boards/shields/x_nucleo_iks01a2/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a2/doc/index.rst
@@ -42,7 +42,7 @@ X-NUCLEO-IKS01A2 provides the following key features:
 
 
 More information about X-NUCLEO-IKS01A2 can be found here:
-       - `X-NUCLEO-IKS01A2 data sheet`_
+       - `X-NUCLEO-IKS01A2 databrief`_
 
 
 Programming
@@ -60,5 +60,5 @@ References
 .. _X-NUCLEO-IKS01A2 website:
    http://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
 
-.. _X-NUCLEO-IKS01A2 data sheet:
-   http://www.st.com/resource/en/datasheet/x-nucleo-iks01a2.pdf
+.. _X-NUCLEO-IKS01A2 databrief:
+   http://www.st.com/resource/en/data_brief/x-nucleo-iks01a2.pdf


### PR DESCRIPTION
Update dead URL linking to X-NUCLEO-IKS01A2 datasheet.

I saw that while doing the IDB05A1 documentation, wasn't long to fix it so here is the PR

Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>