### PR TITLE
drivers: spi: spi_ll_stm32: Reset uncleared error flag

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -61,7 +61,19 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 		if (LL_SPI_IsActiveFlag_OVR(spi)) {
 			LL_SPI_ClearFlag_OVR(spi);
 		}
-
+		if (LL_SPI_IsActiveFlag_MODF(spi)) {
+			LL_SPI_ClearFlag_MODF(spi);
+		}
+#if defined (LL_SPI_SR_UDR) || defined(SPI_SR_FRE)
+		if (LL_SPI_IsActiveFlag_FRE(spi)) {
+			LL_SPI_ClearFlag_FRE(spi);
+		}
+#ifdef LL_SPI_SR_UDR
+		if (LL_SPI_IsActiveFlag_UDR(spi)) {
+			LL_SPI_ClearFlag_UDR(spi);
+		}
+#endif /* LL_SPI_SR_UDR */
+#endif /* LL_SPI_SR_UDR || SPI_SR_FRE */
 		return -EIO;
 	}
 


### PR DESCRIPTION
Clear raised error flag, if not done they stay set forever. Thoses changes are based on STM32 HAL SPI HAL_SPI_IRQHandler function.

Follows https://github.com/zephyrproject-rtos/zephyr/pull/8147
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/17363

Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>
Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>