### PR TITLE
drivers: spi: spi_ll_stm32: set NSS before mode

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -302,12 +302,6 @@ static int spi_stm32_configure(struct device *dev,
 
 	LL_SPI_DisableCRC(spi);
 
-	if (config->operation & SPI_OP_MODE_SLAVE) {
-		LL_SPI_SetMode(spi, LL_SPI_MODE_SLAVE);
-	} else {
-		LL_SPI_SetMode(spi, LL_SPI_MODE_MASTER);
-	}
-
 	if (config->cs) {
 		LL_SPI_SetNSSMode(spi, LL_SPI_NSS_SOFT);
 	} else {
@@ -316,6 +310,12 @@ static int spi_stm32_configure(struct device *dev,
 		} else {
 			LL_SPI_SetNSSMode(spi, LL_SPI_NSS_HARD_OUTPUT);
 		}
+	}
+
+	if (config->operation & SPI_OP_MODE_SLAVE) {
+		LL_SPI_SetMode(spi, LL_SPI_MODE_SLAVE);
+	} else {
+		LL_SPI_SetMode(spi, LL_SPI_MODE_MASTER);
 	}
 
 	if (SPI_WORD_SIZE_GET(config->operation) ==  8) {


### PR DESCRIPTION
This commit solve an issue where the NSS must be set before the mode on the stm32mp157c_dk2, else LL_SPI_SetMode won't affect the mode registry.

Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>